### PR TITLE
Add activation caching option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ Alternatively you can import the library and call `run_pipeline` yourself:
 ```python
 from dl_quick_train import run_pipeline
 
-run_pipeline([...])
+run_pipeline([...], activation_cache_dir="/tmp/activations")
 ```
+
+Setting `activation_cache_dir` enables caching of model activations on disk.
+If the directory already contains cached activations for the requested
+configuration, they will be loaded instead of recomputed.
 
 `run_pipeline` accepts a `start_method` argument controlling the
 multiprocessing start method (default: `"forkserver"`). Crash reporting is

--- a/dl_quick_train/__init__.py
+++ b/dl_quick_train/__init__.py
@@ -3,6 +3,7 @@
 from .pipeline import (
     input_fetcher,
     activation_fetcher,
+    activation_loader,
     new_wandb_process,
     log_stats,
     train,
@@ -13,6 +14,7 @@ from .pipeline import (
 __all__ = [
     "input_fetcher",
     "activation_fetcher",
+    "activation_loader",
     "new_wandb_process",
     "log_stats",
     "train",


### PR DESCRIPTION
## Summary
- introduce optional activation caching
- expose new helper `activation_loader`
- document activation cache usage

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_683ed5fb3a388322a64cfa466060db64