### PR TITLE
Add step to W&B logs

### DIFF
--- a/dl_quick_train/pipeline.py
+++ b/dl_quick_train/pipeline.py
@@ -212,7 +212,8 @@ def new_wandb_process(
             if log == "DONE":
                 break
             if isinstance(log, dict):
-                wandb.log(log)
+                step = log.pop("step", None)
+                wandb.log(log, step=step)
             elif isinstance(log, tuple) and log[0] == "artifact":
                 artifact_path = log[1]
                 artifact_name = os.path.basename(artifact_path)
@@ -282,6 +283,7 @@ def log_stats(
             )
             log[f"l0"] = l0
             log["unique_active_features"] = unique_active
+            log["step"] = step
             trainer_log = trainer.get_logging_parameters()
             for name, value in trainer_log.items():
                 if isinstance(value, torch.Tensor):


### PR DESCRIPTION
## Summary
- log the global step number with every wandb log entry
- include the step in metrics produced by `log_stats`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ef777725c832288d7a27a678df7c1