### PR TITLE
Add TransformerLens activation backend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ from dl_quick_train import run_pipeline
 run_pipeline([...], activation_cache_dir="/tmp/activations")
 ```
 
+Set `use_transformer_lens=True` to collect activations with
+[TransformerLens](https://github.com/TransformerOptimus/TransformerLens)
+instead of `nnsight`.
+
 Setting `activation_cache_dir` enables caching of model activations on disk.
 Caches are stored in subdirectories determined by the model name, dataset,
 layer, activation dimension, submodule and sequence length. If the directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "nnsight",
     "tqdm",
     "transformers",
+    "transformer-lens",
     "wandb",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ dictionary-learning
 nnsight
 tqdm
 transformers
+transformer-lens
 wandb


### PR DESCRIPTION
## Summary
- allow `run_pipeline` to collect activations with TransformerLens
- document new option in README
- depend on `transformer-lens`
- ensure names_filter uses list for TransformerLens

## Testing
- `python -m py_compile dl_quick_train/*.py`
- `pip install -e .` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684950ca6b7083228b12b1242fb3ff8e