### PR TITLE
Support early stopping in TL cache

### DIFF
--- a/dl_quick_train/pipeline.py
+++ b/dl_quick_train/pipeline.py
@@ -142,6 +142,7 @@ def run_pipeline(
     run_cfg={},
     use_wandb=False,
     use_transformer_lens=False,
+    stop_at_layer=None,
     wandb_entity=None,
     wandb_project=None,
     save_dir=None,
@@ -232,6 +233,7 @@ def run_pipeline(
                     _, cache = model.run_with_cache(
                         batch.to(device),
                         names_filter=[submodule],
+                        stop_at_layer=stop_at_layer,
                     )
                     act = cache[submodule]
                 else:


### PR DESCRIPTION
## Summary
- pass `stop_at_layer` argument to TransformerLens `run_with_cache`
- expose new argument via `run_pipeline`

## Testing
- `python -m py_compile dl_quick_train/pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_684956f374388322ad268e039faf1424